### PR TITLE
#5 : PR에서 수정한 파일들만 rspec 결과를 리포팅하도록 하는 모드 추가

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31080,16 +31080,75 @@ var __webpack_exports__ = {};
 (() => {
 const core = __nccwpck_require__(4091);
 const github = __nccwpck_require__(3814);
+const fs = __nccwpck_require__(7147);
 
-const FILE_PATH = 'filepath';
+const {GITHUB_TOKEN} = process.env;
+const octokit = github.getOctokit(GITHUB_TOKEN);
 
 try {
-  const {GITHUB_TOKEN} = process.env;
-  const octokit = github.getOctokit(GITHUB_TOKEN);
-
+  const FILE_PATH = 'filepath';
   const rspecResultFilepath = core.getInput(FILE_PATH);
-  console.log("rspec result filepath", rspecResultFilepath);
+  const onlyChangedRspecFile = core.getInput('only-pull-request-files');
+  console.log(onlyChangedRspecFile);
 
+  if (onlyChangedRspecFile === 'true') {
+    fetchPullRequestFiles(github.context)
+      .then(response => {
+        const pullRequestFiles = response.data;
+        const pullRequestFilenames = pullRequestFiles.map(pullRequestFileInfo => extractFilename(pullRequestFileInfo.filename));
+        console.log(pullRequestFilenames);
+        return filterPullRequestFilenames(pullRequestFilenames);
+      })
+      .then(filteredPullRequestFilename => createRspecReportComment(rspecResultFilepath, filteredPullRequestFilename))
+      .then(comment => {
+        octokit.rest.issues.createComment({
+          issue_number: github.context.issue.number,
+          owner: github.context.repo.owner,
+          repo: github.context.repo.repo,
+          body: comment
+        });
+      })
+      .catch(error => {
+        console.log(error);
+        throw new Error(`fetchPullRequestFiles failed : ${error.message}`);
+      });
+  } else {
+    const comment = createRspecReportComment(rspecResultFilepath, []);
+    octokit.rest.issues.createComment({
+      issue_number: github.context.issue.number,
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      body: comment
+    });
+  }
+} catch (error) {
+  core.setFailed(error.message);
+}
+
+// @param githubContext actions/github's context object
+async function fetchPullRequestFiles(githubContext) {
+  return await octokit.rest.pulls.listFiles({
+    owner: githubContext.repo.owner,
+    repo: githubContext.repo.repo,
+    pull_number: githubContext.issue.number
+  });
+}
+
+function filterPullRequestFilenames(pullRequestFilenames) {
+  // 1. *_spec.rb 파일에서 _spec 앞의 이름 추출
+  // 2. *.rb 파일 이름 추출
+  return pullRequestFilenames.filter(changedFilename => changedFilename.endsWith('.rb'))
+    .map(changedRubyFilename => {
+      if (changedRubyFilename.endsWith('_spec.rb')) {
+        return changedRubyFilename;
+      } else {
+        const removeExtFilename = changedRubyFilename.substring(0, changedRubyFilename.length - '.rb'.length);
+        return `${removeExtFilename}_spec.rb`;
+      }
+    });
+}
+
+function createRspecReportComment(rspecResultFilepath, pullRequestRubyFilenames) {
   const fs = __nccwpck_require__(7147);
   const results = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));
 
@@ -31103,30 +31162,35 @@ try {
             `;
 
   results.examples.forEach(testCaseResult => {
+    if (pullRequestRubyFilenames.length !== 0) {
+      const testCaseFilename = extractFilename(testCaseResult.file_path);
+      if (!pullRequestRubyFilenames.includes(testCaseFilename)) {
+        // skip if not included
+        console.log(`${testCaseResult.file_path} is skipped, because it is not included this pull request commits.`);
+        return;
+      }
+    }
+
     if (testCaseResult.status === 'failed') {
       comment += `<tr>\n`;
       comment += `  <td> ${testCaseResult.file_path} </td>\n`;
       comment += `  <td> ${testCaseResult.full_description} </td>\n`;
-      comment += `  <td>\n\n`
+      comment += `  <td>\n\n`;
       comment += `\`\`\`console\n`;
       comment += ` \n${testCaseResult.exception.message}\n \n`;
       comment += `\`\`\`\n\n`;
-      comment += `  </td>\n`
+      comment += `  </td>\n`;
       comment += `</tr>`;
     }
   });
   comment += `</table>`;
 
-  octokit.rest.issues.createComment({
-    issue_number: github.context.issue.number,
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    body: comment
-  });
-} catch (error) {
-  core.setFailed(error.message);
+  return comment;
 }
 
+function extractFilename(filepath) {
+  return filepath.split('/').slice(-1)[0];
+}
 
 })();
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
+const fs = require("fs");
 
 const {GITHUB_TOKEN} = process.env;
 const octokit = github.getOctokit(GITHUB_TOKEN);
@@ -10,25 +11,66 @@ try {
   const onlyChangedRspecFile = core.getInput('only-pull-request-files');
   console.log(onlyChangedRspecFile);
 
+  if (onlyChangedRspecFile === 'true') {
+    fetchPullRequestFiles(github.context)
+      .then(response => {
+        const pullRequestFiles = response.data;
+        const pullRequestFilenames = pullRequestFiles.map(pullRequestFileInfo => extractFilename(pullRequestFileInfo.filename));
+        console.log(pullRequestFilenames);
+        return filterPullRequestFilenames(pullRequestFilenames);
+      })
+      .then(filteredPullRequestFilename => createRspecReportComment(rspecResultFilepath, filteredPullRequestFilename))
+      .then(comment => {
+        octokit.rest.issues.createComment({
+          issue_number: github.context.issue.number,
+          owner: github.context.repo.owner,
+          repo: github.context.repo.repo,
+          body: comment
+        });
+      })
+      .catch(error => {
+        console.log(error);
+        throw new Error(`fetchPullRequestFiles failed : ${error.message}`);
+      });
+  } else {
+    const comment = createRspecReportComment(rspecResultFilepath, []);
+    octokit.rest.issues.createComment({
+      issue_number: github.context.issue.number,
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      body: comment
+    });
+  }
+} catch (error) {
+  core.setFailed(error.message);
+}
+
+// @param githubContext actions/github's context object
+async function fetchPullRequestFiles(githubContext) {
+  return await octokit.rest.pulls.listFiles({
+    owner: githubContext.repo.owner,
+    repo: githubContext.repo.repo,
+    pull_number: githubContext.issue.number
+  });
+}
+
+function filterPullRequestFilenames(pullRequestFilenames) {
+  // 1. *_spec.rb 파일에서 _spec 앞의 이름 추출
+  // 2. *.rb 파일 이름 추출
+  return pullRequestFilenames.filter(changedFilename => changedFilename.endsWith('.rb'))
+    .map(changedRubyFilename => {
+      if (changedRubyFilename.endsWith('_spec.rb')) {
+        return changedRubyFilename;
+      } else {
+        const removeExtFilename = changedRubyFilename.substring(0, changedRubyFilename.length - '.rb'.length);
+        return `${removeExtFilename}_spec.rb`;
+      }
+    });
+}
+
+function createRspecReportComment(rspecResultFilepath, pullRequestRubyFilenames) {
   const fs = require('fs');
   const results = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));
-
-  let pullRequestRubyFilenames = [];
-  if (onlyChangedRspecFile === 'true') {
-    const changedFilenames = fetchPullRequestFilenames(github.context);
-    // 1. *_spec.rb 파일에서 _spec 앞의 이름 추출
-    // 2. *.rb 파일 이름 추출
-    pullRequestRubyFilenames = changedFilenames.filter(changedFilename => changedFilename.endsWith('.rb'))
-      .map(changedRubyFilename => {
-        if (changedRubyFilename.endsWith('_spec.rb')) {
-          return changedRubyFilename;
-        } else {
-          const removeExtFilename = changedRubyFilename.substring(0, changedRubyFilename.length - '.rb'.length);
-          return `${removeExtFilename}_spec.rb`;
-        }
-      });
-    console.log(pullRequestRubyFilenames);
-  }
 
   let comment = `## RSpec Test Results\n\n`;
   comment += `<table>
@@ -41,7 +83,7 @@ try {
 
   results.examples.forEach(testCaseResult => {
     if (pullRequestRubyFilenames.length !== 0) {
-      const testCaseFilename = testCaseResult.file_path.split('/').slice(-1)[0];
+      const testCaseFilename = extractFilename(testCaseResult.file_path);
       if (!pullRequestRubyFilenames.includes(testCaseFilename)) {
         // skip if not included
         console.log(`${testCaseResult.file_path} is skipped, because it is not included this pull request commits.`);
@@ -63,29 +105,9 @@ try {
   });
   comment += `</table>`;
 
-  octokit.issues.createComment({
-    issue_number: github.context.issue.number,
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    body: comment
-  });
-} catch (error) {
-  core.setFailed(error.message);
+  return comment;
 }
 
-// @param githubContext actions/github's context object
-async function fetchPullRequestFilenames(githubContext) {
-  return await octokit.pulls.listFiles({
-    owner: githubContext.repo.owner,
-    repo: githubContext.repo.repo,
-    pull_number: githubContext.issue.number
-  })
-    .then(response => {
-      const pullRequestFileInfoList = response.data;
-      return pullRequestFileInfoList.map(pullRequestFileInfo => pullRequestFileInfo.filename);
-    })
-    .catch(error => {
-      console.log(error);
-      throw new Error(`fetchPullRequestFilenames failed : ${error.message}`);
-    });
+function extractFilename(filepath) {
+  return filepath.split('/').slice(-1)[0];
 }


### PR DESCRIPTION
close #5 

## 개요
- #5 

## 내용
1. 사용자가 action에서 `only-pull-request-files` 모드를 `'true'`로 활성화하게 될 경우, 아래 내용 진행
2. [PR의 파일 내용을 조회하는 GitHub API](https://octokit.github.io/rest.js/v17#pulls-list-files)를 사용하여 파일이름을 추출
3. 추출한 파일이름 중 Ruby 관련 파일만 필터링
4. `.rb` 파일은 뒤에 `_spec.rb` postfix를 다시 붙이고, spec 파일은 원래이름대로 반환
5. 리포팅 시 추출 및 가공한 파일이름과 동일한 rspec 리포팅 결과만 PR comment에 반영

## 진행
기능 구현만을 1차 목표로 진행. 향후 원활한 진행을 위해서 refactoring은 필수. 이후 리팩터링을 진행할 예정

## 참고
top-level에서는 await를 사용할 수가 없어서 callback메서드를 사용하여 구현하도록 변경했기에, 수정사항이 크고 많음.
테스트는 진행함.