### PR TITLE
#8 : PR 파일들만 리포팅하도록 하는 기능 리팩터링

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import {DefaultTemplate} from "./mode/DefaultTemplate";
 import {DefaultReporter} from "./mode/DefaultReporter";
+import {OnlyPRFilesReporter} from "./mode/onlyPullRequestFiles/OnlyPRFilesReporter";
+import {OnlyPRFilesTemplate} from "./mode/onlyPullRequestFiles/OnlyPRFilesTemplate";
 
 const core = require('@actions/core');
 const github = require('@actions/github');
@@ -8,105 +10,21 @@ const {GITHUB_TOKEN} = process.env;
 const octokit = github.getOctokit(GITHUB_TOKEN);
 
 try {
-  const FILE_PATH = 'filepath';
-  const rspecResultFilepath = core.getInput(FILE_PATH);
+  const rspecResultFilepath = core.getInput('filepath');
   const onlyChangedRspecFile = core.getInput('only-pull-request-files');
 
-  if (onlyChangedRspecFile === 'true') {
-    fetchPullRequestFiles(github.context)
-      .then(response => {
-        const pullRequestFiles = response.data;
-        const pullRequestFilenames = pullRequestFiles.map(pullRequestFileInfo => extractFilename(pullRequestFileInfo.filename));
-        return filterPullRequestFilenames(pullRequestFilenames);
-      })
-      .then(filteredPullRequestFilename => createRspecReportComment(rspecResultFilepath, filteredPullRequestFilename))
-      .then(comment => {
-        octokit.rest.issues.createComment({
-          issue_number: github.context.issue.number,
-          owner: github.context.repo.owner,
-          repo: github.context.repo.repo,
-          body: comment
-        });
-      })
-      .catch(error => {
-        console.log(error);
-        throw new Error(`fetchPullRequestFiles failed : ${error.message}`);
-      });
-  } else {
-    const fs = require('fs');
-    const results = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));
+  const fs = require('fs');
+  const rspecResult = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));
 
+  if (onlyChangedRspecFile === 'true') {
+    const onlyPRFilesTemplate = new OnlyPRFilesTemplate();
+    const onlyPRFilesReporter = new OnlyPRFilesReporter(octokit, onlyPRFilesTemplate, github.context);
+    onlyPRFilesReporter.reportRspecResult(rspecResult);
+  } else {
     const defaultTemplate = new DefaultTemplate();
     const defaultReporter = new DefaultReporter(octokit, defaultTemplate, github.context);
-    defaultReporter.reportRspecResult(results);
+    defaultReporter.reportRspecResult(rspecResult);
   }
 } catch (error) {
   core.setFailed(error.message);
-}
-
-// @param githubContext actions/github's context object
-async function fetchPullRequestFiles(githubContext) {
-  return await octokit.rest.pulls.listFiles({
-    owner: githubContext.repo.owner,
-    repo: githubContext.repo.repo,
-    pull_number: githubContext.issue.number
-  });
-}
-
-function filterPullRequestFilenames(pullRequestFilenames) {
-  // 1. *_spec.rb 파일에서 _spec 앞의 이름 추출
-  // 2. *.rb 파일 이름 추출
-  return pullRequestFilenames.filter(changedFilename => changedFilename.endsWith('.rb'))
-    .map(changedRubyFilename => {
-      if (changedRubyFilename.endsWith('_spec.rb')) {
-        return changedRubyFilename;
-      } else {
-        const removeExtFilename = changedRubyFilename.substring(0, changedRubyFilename.length - '.rb'.length);
-        return `${removeExtFilename}_spec.rb`;
-      }
-    });
-}
-
-function createRspecReportComment(rspecResultFilepath, pullRequestRubyFilenames) {
-  const fs = require('fs');
-  const results = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));
-
-  let comment = `## RSpec Test Results\n\n`;
-  comment += `<table>
-                <tr>
-                  <td> rspec path </td> 
-                  <td> full description </td>
-                  <td> detail error message </td>
-                </tr>
-            `;
-
-  results.examples.forEach(testCaseResult => {
-    if (pullRequestRubyFilenames.length !== 0) {
-      const testCaseFilename = extractFilename(testCaseResult.file_path);
-      if (!pullRequestRubyFilenames.includes(testCaseFilename)) {
-        // skip if not included
-        console.log(`${testCaseResult.file_path} is skipped, because it is not included this pull request commits.`);
-        return;
-      }
-    }
-
-    if (testCaseResult.status === 'failed') {
-      comment += `<tr>\n`;
-      comment += `  <td> ${testCaseResult.file_path} </td>\n`;
-      comment += `  <td> ${testCaseResult.full_description} </td>\n`;
-      comment += `  <td>\n\n`;
-      comment += `\`\`\`console\n`;
-      comment += ` \n${testCaseResult.exception.message}\n \n`;
-      comment += `\`\`\`\n\n`;
-      comment += `  </td>\n`;
-      comment += `</tr>`;
-    }
-  });
-  comment += `</table>`;
-
-  return comment;
-}
-
-function extractFilename(filepath) {
-  return filepath.split('/').slice(-1)[0];
 }

--- a/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
@@ -20,17 +20,17 @@ export class OnlyPRFilesReporter {
    * @param rspecResult {JSON} rspec result (JSON format)
    */
   reportRspecResult(rspecResult) {
-    this.fetchPullRequestFiles()
+    this.#fetchPullRequestFiles()
       .then(response => {
         const pullRequestFiles = response.data;
-        return pullRequestFiles.map(pullRequestFile => this.extractFilenameFromPath(pullRequestFile.filename));
+        return pullRequestFiles.map(pullRequestFile => this.#extractFilenameFromPath(pullRequestFile.filename));
       })
-      .then(pullRequestFilenames => this.filterOnlyRubyFiles(pullRequestFilenames))
-      .then(pullRequestRubyFilenames => this.convertRubyFilenameToRspecFilenames(pullRequestRubyFilenames))
+      .then(pullRequestFilenames => this.#filterOnlyRubyFiles(pullRequestFilenames))
+      .then(pullRequestRubyFilenames => this.#convertRubyFilenameToRspecFilenames(pullRequestRubyFilenames))
       .then(pullRequestRspecFilenames => {
-        const rspecCasesResult = this.extractRspecResult(rspecResult, pullRequestRspecFilenames);
-        const content = this.drawPullRequestComment(rspecCasesResult);
-        this.createCommentToPullRequest(content);
+        const rspecCasesResult = this.#extractRspecResult(rspecResult, pullRequestRspecFilenames);
+        const content = this.#drawPullRequestComment(rspecCasesResult);
+        this.#createCommentToPullRequest(content);
       })
       .catch(error => {
         console.log(error);
@@ -38,7 +38,7 @@ export class OnlyPRFilesReporter {
       });
   }
 
-  async fetchPullRequestFiles() {
+  async #fetchPullRequestFiles() {
     return await this.octokit.rest.pulls.listFiles({
       owner: this.githubContext.repo.owner,
       repo: this.githubContext.repo.repo,
@@ -52,11 +52,11 @@ export class OnlyPRFilesReporter {
    * @param filepath {string} file path of rspec. <br>ex: `".github/workflows/product_spec.rb"`
    * @returns {string} filename. ex: `product_spec.rb`
    */
-  extractFilenameFromPath(filepath) {
+  #extractFilenameFromPath(filepath) {
     try {
       return filepath.split('/').slice(-1)[0];
     } catch (error) {
-      console.log(`OnlyPRFilesReporter.extractFilenameFromPath failed : ${error.message}`);
+      console.log(`OnlyPRFilesReporter.#extractFilenameFromPath failed : ${error.message}`);
       return '';
     }
   }
@@ -67,7 +67,7 @@ export class OnlyPRFilesReporter {
    * @param pullRequestFilenames {Array<string>} pull request filenames
    * @returns {Array<string>} ruby filenames
    */
-  filterOnlyRubyFiles(pullRequestFilenames) {
+  #filterOnlyRubyFiles(pullRequestFilenames) {
     return pullRequestFilenames.filter(pullRequestFilename => pullRequestFilename.endsWith('.rb'));
   }
 
@@ -82,7 +82,7 @@ export class OnlyPRFilesReporter {
    * @param pullRequestFilenames {Array<string>} pull request filenames
    * @returns {Array<string>} ruby rspec filenames
    */
-  convertRubyFilenameToRspecFilenames(pullRequestFilenames) {
+  #convertRubyFilenameToRspecFilenames(pullRequestFilenames) {
     return pullRequestFilenames.map(pullRequestRubyFilename => {
       if (pullRequestRubyFilename.endsWith('_spec.rb')) {
         return pullRequestRubyFilename;
@@ -103,11 +103,11 @@ export class OnlyPRFilesReporter {
    * @param pullRequestRspecFilenames {Array<string>} rspec filenames
    * @returns [RspecCaseResult] rspec cases result in pull requested files
    */
-  extractRspecResult(rspecResult, pullRequestRspecFilenames) {
-    console.log("extractRspecResult START!");
+  #extractRspecResult(rspecResult, pullRequestRspecFilenames) {
+    console.log("#extractRspecResult START!");
     return rspecResult.examples
       .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
-      .filter(failedRspecCaseResult => this.isPullRequestFiles(failedRspecCaseResult, pullRequestRspecFilenames))
+      .filter(failedRspecCaseResult => this.#isPullRequestFiles(failedRspecCaseResult, pullRequestRspecFilenames))
       .map(failedRspecCaseResult => {
         return {
           filepath: failedRspecCaseResult.file_path,
@@ -124,8 +124,8 @@ export class OnlyPRFilesReporter {
    * @param pullRequestedFilenames {Array<string>} pull requested filenames
    * @returns {boolean} return `true` if it is pull requested filename, otherwise return false.
    */
-  isPullRequestFiles(rspecCaseResult, pullRequestedFilenames) {
-    const filename = this.extractFilenameFromPath(rspecCaseResult.file_path);
+  #isPullRequestFiles(rspecCaseResult, pullRequestedFilenames) {
+    const filename = this.#extractFilenameFromPath(rspecCaseResult.file_path);
     return pullRequestedFilenames.includes(filename);
   }
 
@@ -133,11 +133,11 @@ export class OnlyPRFilesReporter {
    * draw report result for comment to pull request.<br>
    * return comment content string.
    *
-   * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `extractRspecResult` method.
+   * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `#extractRspecResult` method.
    * @returns {string} report content
    */
-  drawPullRequestComment(rspecCasesResult) {
-    console.log("drawPullRequestComment START!!");
+  #drawPullRequestComment(rspecCasesResult) {
+    console.log("#drawPullRequestComment START!!");
     const header = this.template.formatter(this.template.header());
     const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
       const filepath = rspecCaseResult.filepath;
@@ -159,7 +159,7 @@ export class OnlyPRFilesReporter {
    *
    * @param content {String} rspec report content
    */
-  createCommentToPullRequest(content) {
+  #createCommentToPullRequest(content) {
     this.octokit.rest.issues.createComment({
       issue_number: this.githubContext.issue.number,
       owner: this.githubContext.repo.owner,

--- a/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
@@ -1,0 +1,166 @@
+import {trimEachLines} from "../../utils/StringUtils";
+
+export class OnlyPRFilesReporter {
+  /**
+   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
+   * @param template {OnlyPRFilesTemplate} Template class. `DefaultReporter` use `DefaultTemplate`.
+   * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
+   */
+  constructor(octokit, template, githubContext) {
+    this.name = "OnlyPRFilesReporter";
+    this.octokit = octokit;
+    this.template = template;
+    this.githubContext = githubContext;
+  }
+
+  /**
+   * Parse rspec result file and create pull request comment.
+   *
+   * @param rspecResult {JSON} rspec result (JSON format)
+   */
+  reportRspecResult(rspecResult) {
+    this.fetchPullRequestFiles()
+      .then(response => {
+        const pullRequestFiles = response.data;
+        return pullRequestFiles.map(pullRequestFile => this.extractFilenameFromPath(pullRequestFile.filename));
+      })
+      .then(pullRequestFilenames => this.filterOnlyRubyFiles(pullRequestFilenames))
+      .then(pullRequestRubyFilenames => this.convertRspecFilenames(pullRequestRubyFilenames))
+      .then(pullRequestRspecFilenames => {
+        const rspecCasesResult = this.extractRspecResult(rspecResult, pullRequestRspecFilenames);
+        const content = this.drawPullRequestComment(rspecCasesResult);
+        this.createCommentToPullRequest(content);
+      })
+
+  }
+
+  async fetchPullRequestFiles() {
+    return await this.octokit.rest.pulls.listFiles({
+      owner: this.githubContext.repo.owner,
+      repo: this.githubContext.repo.repo,
+      pull_number: this.githubContext.issue.number
+    });
+  }
+
+  /**
+   * extract filename from filepath.
+   *
+   * @param filepath {string} file path of rspec. <br>ex: `".github/workflows/product_spec.rb"`
+   * @returns {string} filename. ex: `product_spec.rb`
+   */
+  extractFilenameFromPath(filepath) {
+    try {
+      return filepath.split('/').slice(-1)[0];
+    } catch (error) {
+      console.log(`OnlyPRFilesReporter.extractFilenameFromPath failed : ${error.message}`);
+      return '';
+    }
+  }
+
+  /**
+   * filter only ruby filenames.
+   *
+   * @param pullRequestFilenames {Array<string>} pull request filenames
+   * @returns {Array<string>} ruby filenames
+   */
+  filterOnlyRubyFiles(pullRequestFilenames) {
+    return pullRequestFilenames.filter(pullRequestFilename => pullRequestFilename.endsWith('.rb'));
+  }
+
+  /**
+   * make .rb or _spec.rb filename to spec filename.<br>
+   * we need to execute rspec when original file is changed.
+   *
+   * @example
+   * `hello.rb` --> `hello_spec.rb` (changed)
+   * `hello_service_spec.rb` --> `hello_service_spec.rb` (not changed)
+   * `hello.txt` --> `` (empty string)
+   * @param pullRequestFilenames {Array<string>} pull request filenames
+   * @returns {Array<string>} ruby rspec filenames
+   */
+  convertRspecFilenames(pullRequestFilenames) {
+    return pullRequestFilenames.map(pullRequestRubyFilename => {
+      if (pullRequestRubyFilename.endsWith('_spec.rb')) {
+        return pullRequestRubyFilename;
+      } else if (pullRequestRubyFilename.endsWith('.rb')) {
+        const removeExtFilename = pullRequestRubyFilename.substring(0, pullRequestRubyFilename.length - '.rb'.length);
+        return `${removeExtFilename}_spec.rb`;
+      } else {
+        return '';
+      }
+    });
+  }
+
+  /**
+   * iterate rspec each cases and extract `filepath`, `full desc`, `detail message`.<br>
+   * It return extracted rspec failed results by case.
+   *
+   * @param rspecResult {JSON} rspec result (JSON format)
+   * @param pullRequestRspecFilenames {Array<string>} rspec filenames
+   * @returns [RspecCaseResult] rspec cases result in pull requested files
+   */
+  extractRspecResult(rspecResult, pullRequestRspecFilenames) {
+    console.log("extractRspecResult START!");
+    return rspecResult.examples
+      .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
+      .filter(failedRspecCaseResult => this.isPullRequestFiles(failedRspecCaseResult, pullRequestRspecFilenames))
+      .map(failedRspecCaseResult => {
+        return {
+          filepath: failedRspecCaseResult.file_path,
+          fullDescription: failedRspecCaseResult.full_description,
+          exceptionMessage: failedRspecCaseResult.exception.message
+        }
+      });
+  }
+
+  /**
+   * check rspec case is in the pull request files
+   *
+   * @param rspecCaseResult {JSON} rspec case result example
+   * @param pullRequestedFilenames {Array<string>} pull requested filenames
+   * @returns {boolean} return `true` if it is pull requested filename, otherwise return false.
+   */
+  isPullRequestFiles(rspecCaseResult, pullRequestedFilenames) {
+    const filename = this.extractFilenameFromPath(rspecCaseResult.file_path);
+    return pullRequestedFilenames.includes(filename);
+  }
+
+  /**
+   * draw report result for comment to pull request.<br>
+   * return comment content string.
+   *
+   * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `extractRspecResult` method.
+   * @returns String
+   */
+  drawPullRequestComment(rspecCasesResult) {
+    console.log("drawPullRequestComment START!!");
+    const header = this.template.formatter(this.template.header());
+    const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
+      const filepath = rspecCaseResult.filepath;
+      const fullDescription = rspecCaseResult.fullDescription;
+      const exceptionMessage = rspecCaseResult.exceptionMessage;
+      return this.template.formatter(this.template.body(), filepath, fullDescription, exceptionMessage);
+    }).join("\n");
+    const footer = this.template.formatter(this.template.footer());
+
+    return `
+    ${trimEachLines(header)}
+    ${trimEachLines(rspecResultBody)}
+    ${trimEachLines(footer)}
+    `;
+  }
+
+  /**
+   * create pull request comment.
+   *
+   * @param content {String} rspec report content
+   */
+  createCommentToPullRequest(content) {
+    this.octokit.rest.issues.createComment({
+      issue_number: this.githubContext.issue.number,
+      owner: this.githubContext.repo.owner,
+      repo: this.githubContext.repo.repo,
+      body: content
+    });
+  }
+}

--- a/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
@@ -14,7 +14,8 @@ export class OnlyPRFilesReporter {
   }
 
   /**
-   * Parse rspec result file and create pull request comment.
+   * Parse rspec result file and create pull request comment.<br>
+   * Report rspec result only in pull requested files.
    *
    * @param rspecResult {JSON} rspec result (JSON format)
    */
@@ -25,13 +26,16 @@ export class OnlyPRFilesReporter {
         return pullRequestFiles.map(pullRequestFile => this.extractFilenameFromPath(pullRequestFile.filename));
       })
       .then(pullRequestFilenames => this.filterOnlyRubyFiles(pullRequestFilenames))
-      .then(pullRequestRubyFilenames => this.convertRspecFilenames(pullRequestRubyFilenames))
+      .then(pullRequestRubyFilenames => this.convertRubyFilenameToRspecFilenames(pullRequestRubyFilenames))
       .then(pullRequestRspecFilenames => {
         const rspecCasesResult = this.extractRspecResult(rspecResult, pullRequestRspecFilenames);
         const content = this.drawPullRequestComment(rspecCasesResult);
         this.createCommentToPullRequest(content);
       })
-
+      .catch(error => {
+        console.log(error);
+        throw new Error(`OnlyPRFilesReporter.reportRspecResult failed : ${error.message}`);
+      });
   }
 
   async fetchPullRequestFiles() {
@@ -78,7 +82,7 @@ export class OnlyPRFilesReporter {
    * @param pullRequestFilenames {Array<string>} pull request filenames
    * @returns {Array<string>} ruby rspec filenames
    */
-  convertRspecFilenames(pullRequestFilenames) {
+  convertRubyFilenameToRspecFilenames(pullRequestFilenames) {
     return pullRequestFilenames.map(pullRequestRubyFilename => {
       if (pullRequestRubyFilename.endsWith('_spec.rb')) {
         return pullRequestRubyFilename;
@@ -130,7 +134,7 @@ export class OnlyPRFilesReporter {
    * return comment content string.
    *
    * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `extractRspecResult` method.
-   * @returns String
+   * @returns {string} report content
    */
   drawPullRequestComment(rspecCasesResult) {
     console.log("drawPullRequestComment START!!");

--- a/mode/onlyPullRequestFiles/OnlyPRFilesTemplate.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesTemplate.js
@@ -1,0 +1,74 @@
+export class OnlyPRFilesTemplate {
+  constructor() {
+    this.name = "OnlyPRFilesTemplate";
+    this.formatter = (template, ...args) => {
+      return template.replace(/@{([0-9]+)}/g, function (match, index) {
+        return typeof args[index] === 'undefined' ? match : args[index];
+      });
+    };
+  }
+
+  header() {
+    return `
+    ## Rspec Test Results
+    
+    <table>
+      <tr>
+        <td> rspec filepath </td>
+        <td> full description </td>
+        <td> detail error message </td>
+      </tr>
+    `;
+  }
+
+  body() {
+    return `
+      <tr>
+        <td> @{0} </td>
+        <td> @{1} </td>
+        <td>
+        
+          \`\`\`console
+          
+          @{2}
+          
+          \`\`\`
+        
+        </td>
+      </tr>
+    `;
+  }
+
+  footer() {
+    return `
+    </table>
+    `;
+  }
+
+  templateString() {
+    return `
+    ## Rspec Test Results
+    
+    <table>
+      <tr>
+        <td> rspec filepath </td>
+        <td> full description </td>
+        <td> detail error message </td>
+      </tr>
+      <tr>
+        <td> @{0} </td>
+        <td> @{1} </td>
+        <td>
+        
+          \`\`\`console
+          
+          @{2}
+          
+          \`\`\`
+        
+        </td>
+      </tr>
+    </table>
+    `;
+  }
+}


### PR DESCRIPTION
- 이전 PR : https://github.com/xi-jjun/rspec-reporter/pull/9
- issue : #8 

## 진행
1. 기본 로직 리팩터링 : https://github.com/xi-jjun/rspec-reporter/pull/9
2. [현재 PR] 신규 로직 리팩터링
3. 팩토리 메서드 패턴으로 사용자가 사용하고자 하는 모드로 reporter 클래스를 자동선택하여 처리하도록 수정

## 구현
- 로직 변경사항 없음.
- `OnlyPRFilesReporter` 추가

## 참고
중복 로직들이 있는데, 3번째 리팩토링에서 default에 기본 로직 다 넣어놓고 상속 받아서 사용하도록 수정할 예정