### PR TITLE
#8 : 공통 reporter, template 객체를 생성하여 상속받도록 리팩터링

### DIFF
--- a/exceptions/NotImplementedException.js
+++ b/exceptions/NotImplementedException.js
@@ -1,0 +1,6 @@
+export class NotImplementedException extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "NotImplementedException";
+  }
+}

--- a/mode/Reporter.js
+++ b/mode/Reporter.js
@@ -1,0 +1,58 @@
+import {NotImplementedException} from "../exceptions/NotImplementedException";
+import {trimEachLines} from "../utils/StringUtils";
+
+export class Reporter {
+  /**
+   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
+   * @param template {Template} Template class.
+   * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
+   */
+  constructor(octokit, template, githubContext) {
+    this.name = "Reporter";
+    this.octokit = octokit;
+    this.template = template;
+    this.githubContext = githubContext;
+  }
+
+  /**
+   * Parse rspec result file and create pull request comment.
+   *
+   * @param rspecResult {JSON} rspec result (JSON format). It is result of executing rspec.
+   */
+  reportRspecResult(rspecResult) {
+    try {
+      this.notImplementedError();
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  notImplementedError() {
+    throw new NotImplementedException('You should implement this in child class');
+  }
+
+  /**
+   * Draw report result for comment to pull request.<br>
+   * Return comment content string. This method is common logic.
+   *
+   * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `extractRspecResult` method.
+   * @returns {string} return report result content. This content is going to be added pull request comment
+   */
+  drawPullRequestComment(rspecCasesResult) {
+    console.log("drawPullRequestComment START!!");
+    const header = this.template.formatter(this.template.header());
+    const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
+      const filepath = rspecCaseResult.filepath;
+      const fullDescription = rspecCaseResult.fullDescription;
+      const exceptionMessage = rspecCaseResult.exceptionMessage;
+      return this.template.formatter(this.template.body(), filepath, fullDescription, exceptionMessage);
+    }).join("\n");
+    const footer = this.template.formatter(this.template.footer());
+
+    return `
+    ${trimEachLines(header)}
+    ${trimEachLines(rspecResultBody)}
+    ${trimEachLines(footer)}
+    `;
+  }
+}

--- a/mode/Template.js
+++ b/mode/Template.js
@@ -1,0 +1,73 @@
+export class Template {
+  constructor() {
+    this.formatter = (template, ...args) => {
+      return template.replace(/@{([0-9]+)}/g, function (match, index) {
+        return typeof args[index] === 'undefined' ? match : args[index];
+      });
+    };
+  }
+
+  header() {
+    return `
+    ## Rspec Test Results
+    
+    <table>
+      <tr>
+        <td> rspec filepath </td>
+        <td> full description </td>
+        <td> detail error message </td>
+      </tr>
+    `;
+  }
+
+  body() {
+    return `
+      <tr>
+        <td> @{0} </td>
+        <td> @{1} </td>
+        <td>
+        
+          \`\`\`console
+          
+          @{2}
+          
+          \`\`\`
+        
+        </td>
+      </tr>
+    `;
+  }
+
+  footer() {
+    return `
+    </table>
+    `;
+  }
+
+  fullTemplate() {
+    return `
+    ## Rspec Test Results
+    
+    <table>
+      <tr>
+        <td> rspec filepath </td>
+        <td> full description </td>
+        <td> detail error message </td>
+      </tr>
+      <tr>
+        <td> @{0} </td>
+        <td> @{1} </td>
+        <td>
+        
+          \`\`\`console
+          
+          @{2}
+          
+          \`\`\`
+        
+        </td>
+      </tr>
+    </table>
+    `;
+  }
+}

--- a/mode/default/DefaultReporter.js
+++ b/mode/default/DefaultReporter.js
@@ -1,16 +1,14 @@
-import {trimEachLines} from "../../utils/StringUtils";
+import {Reporter} from "../Reporter";
 
-export class DefaultReporter {
+export class DefaultReporter extends Reporter {
   /**
    * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {DefaultTemplate} Template class. `DefaultReporter` use `DefaultTemplate`.
    * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
    */
   constructor(octokit, template, githubContext) {
+    super(octokit, template, githubContext);
     this.name = "DefaultReporter";
-    this.octokit = octokit;
-    this.template = template;
-    this.githubContext = githubContext;
   }
 
   /**
@@ -43,31 +41,6 @@ export class DefaultReporter {
         exceptionMessage: rspecCaseResult.exception.message
       }
     });
-  }
-
-  /**
-   * draw report result for comment to pull request.<br>
-   * return comment content string.
-   *
-   * @param rspecCasesResult {Array<RspecCaseResult>} list for rspec each cases result. More detail in `extractRspecResult` method.
-   * @returns String
-   */
-  drawPullRequestComment(rspecCasesResult) {
-    console.log("drawPullRequestComment START!!");
-    const header = this.template.formatter(this.template.header());
-    const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
-      const filepath = rspecCaseResult.filepath;
-      const fullDescription = rspecCaseResult.fullDescription;
-      const exceptionMessage = rspecCaseResult.exceptionMessage;
-      return this.template.formatter(this.template.body(), filepath, fullDescription, exceptionMessage);
-    }).join("\n");
-    const footer = this.template.formatter(this.template.footer());
-
-    return `
-    ${trimEachLines(header)}
-    ${trimEachLines(rspecResultBody)}
-    ${trimEachLines(footer)}
-    `;
   }
 
   /**

--- a/mode/default/DefaultTemplate.js
+++ b/mode/default/DefaultTemplate.js
@@ -1,74 +1,8 @@
-export class DefaultTemplate {
+import {Template} from "../Template";
+
+export class DefaultTemplate extends Template {
   constructor() {
+    super();
     this.name = "DefaultTemplate";
-    this.formatter = (template, ...args) => {
-      return template.replace(/@{([0-9]+)}/g, function (match, index) {
-        return typeof args[index] === 'undefined' ? match : args[index];
-      });
-    };
-  }
-
-  header() {
-    return `
-    ## Rspec Test Results
-    
-    <table>
-      <tr>
-        <td> rspec filepath </td>
-        <td> full description </td>
-        <td> detail error message </td>
-      </tr>
-    `;
-  }
-
-  body() {
-    return `
-      <tr>
-        <td> @{0} </td>
-        <td> @{1} </td>
-        <td>
-        
-          \`\`\`console
-          
-          @{2}
-          
-          \`\`\`
-        
-        </td>
-      </tr>
-    `;
-  }
-
-  footer() {
-    return `
-    </table>
-    `;
-  }
-
-  templateString() {
-    return `
-    ## Rspec Test Results
-    
-    <table>
-      <tr>
-        <td> rspec filepath </td>
-        <td> full description </td>
-        <td> detail error message </td>
-      </tr>
-      <tr>
-        <td> @{0} </td>
-        <td> @{1} </td>
-        <td>
-        
-          \`\`\`console
-          
-          @{3}
-          
-          \`\`\`
-        
-        </td>
-      </tr>
-    </table>
-    `;
   }
 }

--- a/mode/onlyPullRequestFiles/OnlyPRFilesTemplate.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesTemplate.js
@@ -1,74 +1,8 @@
-export class OnlyPRFilesTemplate {
+import {Template} from "../Template";
+
+export class OnlyPRFilesTemplate extends Template {
   constructor() {
+    super();
     this.name = "OnlyPRFilesTemplate";
-    this.formatter = (template, ...args) => {
-      return template.replace(/@{([0-9]+)}/g, function (match, index) {
-        return typeof args[index] === 'undefined' ? match : args[index];
-      });
-    };
-  }
-
-  header() {
-    return `
-    ## Rspec Test Results
-    
-    <table>
-      <tr>
-        <td> rspec filepath </td>
-        <td> full description </td>
-        <td> detail error message </td>
-      </tr>
-    `;
-  }
-
-  body() {
-    return `
-      <tr>
-        <td> @{0} </td>
-        <td> @{1} </td>
-        <td>
-        
-          \`\`\`console
-          
-          @{2}
-          
-          \`\`\`
-        
-        </td>
-      </tr>
-    `;
-  }
-
-  footer() {
-    return `
-    </table>
-    `;
-  }
-
-  templateString() {
-    return `
-    ## Rspec Test Results
-    
-    <table>
-      <tr>
-        <td> rspec filepath </td>
-        <td> full description </td>
-        <td> detail error message </td>
-      </tr>
-      <tr>
-        <td> @{0} </td>
-        <td> @{1} </td>
-        <td>
-        
-          \`\`\`console
-          
-          @{2}
-          
-          \`\`\`
-        
-        </td>
-      </tr>
-    </table>
-    `;
   }
 }


### PR DESCRIPTION
- 이전 PR : https://github.com/xi-jjun/rspec-reporter/pull/11
- issue : #8 

## 진행
1. 기본 로직 리팩터링 : https://github.com/xi-jjun/rspec-reporter/pull/9
2. 신규 로직 리팩터링 : https://github.com/xi-jjun/rspec-reporter/pull/10
3. 팩토리 메서드 패턴으로 사용자가 사용하고자 하는 모드로 reporter 클래스를 자동선택하여 처리하도록 수정 https://github.com/xi-jjun/rspec-reporter/pull/11
4. [현재 PR] reporter 공통 로직 상속처리
5. (new!!) Github API 서비스를 모듈로 분리

## 구현
- 로직 변경 없음. 단순 리팩터링
- `Reporter`, `Template` 클래스를 만들어서 공통 로직을 거기에 두도록 만듦. 그리고 각 mode별 기능은 해당 클래스를 상속하여 구현되도록 함.