### PR TITLE
#8 : GitHub API 요청을 모듈로 분리하는 리팩터링

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31121,15 +31121,14 @@ const trimEachLines = (str, splitChar = "\n", joinChar = "\n") => {
 
 
 
+
 class Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {Template} Template class.
-   * @param gitHubApi {GitHubApi} GitHub API module class.
+   * @param gitHubApi {GitHubApi} GitHub API module class for using GitHub api.
    */
-  constructor(octokit, template, gitHubApi) {
+  constructor(template, gitHubApi) {
     this.name = "Reporter";
-    this.octokit = octokit;
     this.template = template;
     this.gitHubApi = gitHubApi;
   }
@@ -31182,12 +31181,11 @@ class Reporter {
 
 class DefaultReporter extends Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {DefaultTemplate} Template class. `DefaultReporter` use `DefaultTemplate`.
    * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, gitHubApi) {
-    super(octokit, template, gitHubApi);
+  constructor(template, gitHubApi) {
+    super(template, gitHubApi);
     this.name = "DefaultReporter";
   }
 
@@ -31330,12 +31328,11 @@ class DefaultTemplateFactory {
 
 class OnlyPRFilesReporter extends Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {Template} Template class. `OnlyPRFilesReporter` use `OnlyPRFilesTemplate`.
    * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, gitHubApi) {
-    super(octokit, template, gitHubApi);
+  constructor(template, gitHubApi) {
+    super(template, gitHubApi);
     this.name = "OnlyPRFilesReporter";
   }
 
@@ -31563,7 +31560,7 @@ class ReporterFactory {
 
     const gitHubApi = new GitHubApi(octokit, githubContext);
 
-    return reporterFactory.createReporter(octokit, template, gitHubApi);
+    return reporterFactory.createReporter(template, gitHubApi);
   }
 }
 
@@ -31579,7 +31576,9 @@ const octokit = github.getOctokit(GITHUB_TOKEN);
 try {
   const rspecResultFilepath = core.getInput('filepath');
   const reportMode = core.getInput('report-mode');
-  console.log(`report mode is [${reportMode}]`);
+  console.log('== inputs ==');
+  console.log(`mode : ${reportMode}`);
+  console.log(`filepath : ${rspecResultFilepath}`);
 
   const fs = __nccwpck_require__(7147);
   const rspecResult = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -31158,7 +31158,6 @@ class Reporter {
    * @returns {string} return report result content. This content is going to be added pull request comment
    */
   drawPullRequestComment(rspecCasesResult) {
-    console.log("drawPullRequestComment START!!");
     const header = this.template.formatter(this.template.header());
     const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
       const filepath = rspecCaseResult.filepath;
@@ -31208,17 +31207,15 @@ class DefaultReporter extends Reporter {
    * @returns [RspecCaseResult]
    */
   extractRspecResult(rspecResult) {
-    console.log("extractRspecResult START!");
     return rspecResult.examples
       .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
       .map(rspecCaseResult => {
-      console.log(rspecCaseResult);
-      return {
-        filepath: rspecCaseResult.file_path,
-        fullDescription: rspecCaseResult.full_description,
-        exceptionMessage: rspecCaseResult.exception.message
-      }
-    });
+        return {
+          filepath: rspecCaseResult.file_path,
+          fullDescription: rspecCaseResult.full_description,
+          exceptionMessage: rspecCaseResult.exception.message
+        }
+      });
   }
 }
 
@@ -31419,7 +31416,6 @@ class OnlyPRFilesReporter extends Reporter {
    * @returns [RspecCaseResult] rspec cases result in pull requested files
    */
   #extractRspecResult(rspecResult, pullRequestRspecFilenames) {
-    console.log("#extractRspecResult START!");
     return rspecResult.examples
       .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
       .filter(failedRspecCaseResult => this.#isPullRequestFiles(failedRspecCaseResult, pullRequestRspecFilenames))

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const octokit = github.getOctokit(GITHUB_TOKEN);
 try {
   const rspecResultFilepath = core.getInput('filepath');
   const reportMode = core.getInput('report-mode');
-  console.log(`report mode is [${reportMode}]`);
+  console.log('== inputs ==');
+  console.log(`mode : ${reportMode}`);
+  console.log(`filepath : ${rspecResultFilepath}`);
 
   const fs = require('fs');
   const rspecResult = JSON.parse(fs.readFileSync(rspecResultFilepath, 'utf8'));

--- a/mode/Reporter.js
+++ b/mode/Reporter.js
@@ -5,13 +5,13 @@ export class Reporter {
   /**
    * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {Template} Template class.
-   * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
+   * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, githubContext) {
+  constructor(octokit, template, gitHubApi) {
     this.name = "Reporter";
     this.octokit = octokit;
     this.template = template;
-    this.githubContext = githubContext;
+    this.gitHubApi = gitHubApi;
   }
 
   /**

--- a/mode/Reporter.js
+++ b/mode/Reporter.js
@@ -38,7 +38,6 @@ export class Reporter {
    * @returns {string} return report result content. This content is going to be added pull request comment
    */
   drawPullRequestComment(rspecCasesResult) {
-    console.log("drawPullRequestComment START!!");
     const header = this.template.formatter(this.template.header());
     const rspecResultBody = rspecCasesResult.map(rspecCaseResult => {
       const filepath = rspecCaseResult.filepath;

--- a/mode/Reporter.js
+++ b/mode/Reporter.js
@@ -1,15 +1,14 @@
 import {NotImplementedException} from "../exceptions/NotImplementedException";
 import {trimEachLines} from "../utils/StringUtils";
+import {GitHubApi} from "../modules/GitHubApi";
 
 export class Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {Template} Template class.
-   * @param gitHubApi {GitHubApi} GitHub API module class.
+   * @param gitHubApi {GitHubApi} GitHub API module class for using GitHub api.
    */
-  constructor(octokit, template, gitHubApi) {
+  constructor(template, gitHubApi) {
     this.name = "Reporter";
-    this.octokit = octokit;
     this.template = template;
     this.gitHubApi = gitHubApi;
   }

--- a/mode/ReporterFactory.js
+++ b/mode/ReporterFactory.js
@@ -3,6 +3,7 @@ import {
   OnlyPRFilesReporterFactory,
   OnlyPRFilesTemplateFactory
 } from "./onlyPullRequestFiles/OnlyPRFilesReporterFactory";
+import {GitHubApi} from "../modules/GitHubApi";
 
 const reporters = {
   DefaultReporterFactory,
@@ -45,6 +46,8 @@ export class ReporterFactory {
     const templateFactory = templates[templateFactoryName];
     const template = templateFactory.createTemplate();
 
-    return reporterFactory.createReporter(octokit, template, githubContext);
+    const gitHubApi = new GitHubApi(octokit, githubContext);
+
+    return reporterFactory.createReporter(octokit, template, gitHubApi);
   }
 }

--- a/mode/ReporterFactory.js
+++ b/mode/ReporterFactory.js
@@ -48,6 +48,6 @@ export class ReporterFactory {
 
     const gitHubApi = new GitHubApi(octokit, githubContext);
 
-    return reporterFactory.createReporter(octokit, template, gitHubApi);
+    return reporterFactory.createReporter(template, gitHubApi);
   }
 }

--- a/mode/default/DefaultReporter.js
+++ b/mode/default/DefaultReporter.js
@@ -29,16 +29,14 @@ export class DefaultReporter extends Reporter {
    * @returns [RspecCaseResult]
    */
   extractRspecResult(rspecResult) {
-    console.log("extractRspecResult START!");
     return rspecResult.examples
       .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
       .map(rspecCaseResult => {
-      console.log(rspecCaseResult);
-      return {
-        filepath: rspecCaseResult.file_path,
-        fullDescription: rspecCaseResult.full_description,
-        exceptionMessage: rspecCaseResult.exception.message
-      }
-    });
+        return {
+          filepath: rspecCaseResult.file_path,
+          fullDescription: rspecCaseResult.full_description,
+          exceptionMessage: rspecCaseResult.exception.message
+        }
+      });
   }
 }

--- a/mode/default/DefaultReporter.js
+++ b/mode/default/DefaultReporter.js
@@ -2,12 +2,11 @@ import {Reporter} from "../Reporter";
 
 export class DefaultReporter extends Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {DefaultTemplate} Template class. `DefaultReporter` use `DefaultTemplate`.
    * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, gitHubApi) {
-    super(octokit, template, gitHubApi);
+  constructor(template, gitHubApi) {
+    super(template, gitHubApi);
     this.name = "DefaultReporter";
   }
 

--- a/mode/default/DefaultReporter.js
+++ b/mode/default/DefaultReporter.js
@@ -4,10 +4,10 @@ export class DefaultReporter extends Reporter {
   /**
    * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {DefaultTemplate} Template class. `DefaultReporter` use `DefaultTemplate`.
-   * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
+   * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, githubContext) {
-    super(octokit, template, githubContext);
+  constructor(octokit, template, gitHubApi) {
+    super(octokit, template, gitHubApi);
     this.name = "DefaultReporter";
   }
 
@@ -19,7 +19,7 @@ export class DefaultReporter extends Reporter {
   reportRspecResult(rspecResult) {
     const rspecCasesResult = this.extractRspecResult(rspecResult);
     const content = this.drawPullRequestComment(rspecCasesResult);
-    this.createCommentToPullRequest(content);
+    this.gitHubApi.createCommentToPullRequest(content);
   }
 
   /**
@@ -40,20 +40,6 @@ export class DefaultReporter extends Reporter {
         fullDescription: rspecCaseResult.full_description,
         exceptionMessage: rspecCaseResult.exception.message
       }
-    });
-  }
-
-  /**
-   * create pull request comment.
-   *
-   * @param content {String} rspec report content
-   */
-  createCommentToPullRequest(content) {
-    this.octokit.rest.issues.createComment({
-      issue_number: this.githubContext.issue.number,
-      owner: this.githubContext.repo.owner,
-      repo: this.githubContext.repo.repo,
-      body: content
     });
   }
 }

--- a/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
@@ -93,7 +93,6 @@ export class OnlyPRFilesReporter extends Reporter {
    * @returns [RspecCaseResult] rspec cases result in pull requested files
    */
   #extractRspecResult(rspecResult, pullRequestRspecFilenames) {
-    console.log("#extractRspecResult START!");
     return rspecResult.examples
       .filter(rspecCaseResult => rspecCaseResult.status === 'failed')
       .filter(failedRspecCaseResult => this.#isPullRequestFiles(failedRspecCaseResult, pullRequestRspecFilenames))

--- a/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
+++ b/mode/onlyPullRequestFiles/OnlyPRFilesReporter.js
@@ -2,12 +2,11 @@ import {Reporter} from "../Reporter";
 
 export class OnlyPRFilesReporter extends Reporter {
   /**
-   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
    * @param template {Template} Template class. `OnlyPRFilesReporter` use `OnlyPRFilesTemplate`.
    * @param gitHubApi {GitHubApi} GitHub API module class.
    */
-  constructor(octokit, template, gitHubApi) {
-    super(octokit, template, gitHubApi);
+  constructor(template, gitHubApi) {
+    super(template, gitHubApi);
     this.name = "OnlyPRFilesReporter";
   }
 

--- a/modules/GitHubApi.js
+++ b/modules/GitHubApi.js
@@ -1,0 +1,39 @@
+export class GitHubApi {
+  /**
+   * @param octokit {InstanceType<typeof GitHub>} for using GitHub API.
+   * @param githubContext {InstanceType<typeof Context.Context>} github context object. It contains issue number, repo info etc...
+   */
+  constructor(octokit, githubContext) {
+    this.name = "GitHubApi";
+    this.octokit = octokit;
+    this.githubContext = githubContext;
+  }
+
+  /**
+   * Create pull request comment async.<br>
+   * Body is rspec report content.
+   *
+   * @param content {string} rspec report result
+   */
+  createCommentToPullRequest(content) {
+    this.octokit.rest.issues.createComment({
+      issue_number: this.githubContext.issue.number,
+      owner: this.githubContext.repo.owner,
+      repo: this.githubContext.repo.repo,
+      body: content
+    });
+  }
+
+  /**
+   * Read list of pull request files.
+   *
+   * @returns {Promise} read pull request file list promise object
+   */
+  async readPullRequestFiles() {
+    return await this.octokit.rest.pulls.listFiles({
+      owner: this.githubContext.repo.owner,
+      repo: this.githubContext.repo.repo,
+      pull_number: this.githubContext.issue.number
+    });
+  }
+}


### PR DESCRIPTION
- 이전 PR : https://github.com/xi-jjun/rspec-reporter/pull/12
- issue : #8 

## 진행
1. 기본 로직 리팩터링 : https://github.com/xi-jjun/rspec-reporter/pull/9
2. 신규 로직 리팩터링 : https://github.com/xi-jjun/rspec-reporter/pull/10
3. 팩토리 메서드 패턴으로 사용자가 사용하고자 하는 모드로 reporter 클래스를 자동선택하여 처리하도록 수정 https://github.com/xi-jjun/rspec-reporter/pull/11
4. reporter 공통 로직 상속처리 : https://github.com/xi-jjun/rspec-reporter/pull/12
5. [현재 PR] Github API 서비스를 모듈로 분리

## 구현
- 로직 변경 없음. 단순 리팩터링
- GitHub API를 호출하는 기능을 모듈로 분리하여 Reporter 클래스 생성 시에 주입하도록변경
  - 향후 테스트 코드 추가 시 외부 API에 의존하는 부분과 상관없이 테스트가 가능해질 것으로 기대.